### PR TITLE
Working buttons in Shop Screen

### DIFF
--- a/core/src/com/mygdx/game/Components/Pirate.java
+++ b/core/src/com/mygdx/game/Components/Pirate.java
@@ -12,10 +12,10 @@ import com.mygdx.utils.QueueFIFO;
  */
 public class Pirate extends Component {
     private int factionId;
-    private int plunder;
+    public static int plunder;
     protected boolean isAlive;
-    private int health;
-    private int ammo;
+    public static int health;
+    public static int ammo;
     private final int attackDmg;
 
     /**
@@ -44,7 +44,7 @@ public class Pirate extends Component {
         return plunder;
     }
 
-    public void addPlunder(int money) {
+    public static void addPlunder(int money) {
         plunder += money;
     }
 
@@ -80,10 +80,10 @@ public class Pirate extends Component {
     /**
      * Adds ammo
      *
-     * @param ammo amount to add
+     * @param newAmmo amount to add
      */
-    public void reload(int ammo) {
-        this.ammo += ammo;
+    public static void addAmmo(int newAmmo) {
+        ammo += newAmmo;
     }
 
     public int getHealth() {

--- a/core/src/com/mygdx/game/PirateGame.java
+++ b/core/src/com/mygdx/game/PirateGame.java
@@ -6,10 +6,7 @@ import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.utils.viewport.ScreenViewport;
 import com.mygdx.game.Managers.ResourceManager;
-import com.mygdx.game.UI.EndScreen;
-import com.mygdx.game.UI.GameScreen;
-import com.mygdx.game.UI.MenuScreen;
-import com.mygdx.game.UI.ShopScreen;
+import com.mygdx.game.UI.*;
 
 /**
  * Contains class instances of game UI screens.
@@ -21,6 +18,7 @@ public class PirateGame extends Game {
     public Stage stage;
     public Skin skin;
     public ShopScreen shop;
+    public PowerupScreen powerup;
 
     /**
      * Create instances of game stage and UI screens.
@@ -44,6 +42,7 @@ public class PirateGame extends Game {
         shop = new ShopScreen(this);
         game = new GameScreen(this, id_map);
         end = new EndScreen(this);
+        powerup = new PowerupScreen(this);
         setScreen(menu);
     }
 
@@ -57,6 +56,7 @@ public class PirateGame extends Game {
         game.dispose();
         stage.dispose();
         skin.dispose();
+        powerup.dispose();
     }
 
     /**

--- a/core/src/com/mygdx/game/UI/GameScreen.java
+++ b/core/src/com/mygdx/game/UI/GameScreen.java
@@ -10,6 +10,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.ui.Window;
 import com.badlogic.gdx.utils.ScreenUtils;
 import com.mygdx.game.Components.ComponentEvent;
+import com.mygdx.game.Components.Text;
 import com.mygdx.game.Entitys.Player;
 import com.mygdx.game.Managers.*;
 import com.mygdx.game.PirateGame;
@@ -20,11 +21,16 @@ import java.io.*;
 import static com.mygdx.utils.Constants.*;
 
 public class GameScreen extends Page {
-    private Label healthLabel;
-    private Label dosh;
-    private Label ammo;
-    private final Label questDesc;
-    private final Label questName;
+    public static Label healthLabel;
+    public static Label dosh;
+    public static Label ammo;
+    public static Label questName;
+    public static Label questDesc;
+//    private Label healthLabel;
+//    private Label dosh;
+//    private Label ammo;
+//    private final Label questDesc;
+//    private final Label questName;
     /*private final Label questComplete;
     private float showTimer = 0;
     // in seconds
@@ -127,10 +133,11 @@ public class GameScreen extends Page {
         }
 
         GameManager.update();
-        // show end screen if esc is pressed
+        // show end screen if ESC key is pressed
         if (Gdx.input.isKeyJustPressed(Input.Keys.ESCAPE)) {
             parent.setScreen(parent.end);
         }
+        // show shop screen if E key is pressed
         if (Gdx.input.isKeyJustPressed(Input.Keys.E)) {
             parent.setScreen(parent.shop);
         }

--- a/core/src/com/mygdx/game/UI/MenuScreen.java
+++ b/core/src/com/mygdx/game/UI/MenuScreen.java
@@ -31,7 +31,7 @@ public class MenuScreen extends Page {
         Table t = new Table();
         t.setFillParent(true);
 
-        float space = VIEWPORT_HEIGHT * 0.25f;
+        float space = VIEWPORT_HEIGHT * 0.10f;
 
         t.setBackground(new TextureRegionDrawable(ResourceManager.getTexture("menuBG.jpg")));
         Label l = new Label("Pirates the movie the game", parent.skin);

--- a/core/src/com/mygdx/game/UI/PowerupScreen.java
+++ b/core/src/com/mygdx/game/UI/PowerupScreen.java
@@ -9,29 +9,19 @@ import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;
-import com.badlogic.gdx.utils.ScreenUtils;
-import com.mygdx.game.Components.ComponentEvent;
-import com.mygdx.game.Components.Pirate;
-import com.mygdx.game.Entitys.Player;
-import com.mygdx.game.Managers.EntityManager;
-import com.mygdx.game.Managers.GameManager;
-import com.mygdx.game.Managers.PhysicsManager;
 import com.mygdx.game.Managers.ResourceManager;
 import com.mygdx.game.PirateGame;
 
-import static com.mygdx.utils.Constants.*;
-import static com.mygdx.utils.Constants.PHYSICS_TIME_STEP;
+import static com.mygdx.utils.Constants.TILE_SIZE;
+import static com.mygdx.utils.Constants.VIEWPORT_HEIGHT;
 
 /**
  * Contains widgets defining the shop screen.
  */
-public class ShopScreen extends Page {
-    public ShopScreen(PirateGame parent) {
+public class PowerupScreen extends Page {
+    public PowerupScreen(PirateGame parent) {
         super(parent);
     }
-
-
-    private float accumulator;
 
     /**
      * Called every frame calls all other functions that need to be called every frame by rasing events and update methods
@@ -42,19 +32,9 @@ public class ShopScreen extends Page {
     public void render(float delta) {
         // show game screen if ESC key is pressed
         if (Gdx.input.isKeyJustPressed(Input.Keys.ESCAPE)) {
-            parent.setScreen(parent.game);
+            parent.setScreen(parent.shop);
         }
         super.render(delta);
-    }
-
-    @Override
-    protected void update() {
-        super.update();
-        Player p = GameManager.getPlayer();
-
-        GameScreen.healthLabel.setText(String.valueOf(p.getHealth()));
-        GameScreen.dosh.setText(String.valueOf(p.getPlunder()));
-        GameScreen.ammo.setText(String.valueOf(p.getAmmo()));
     }
 
 
@@ -75,59 +55,65 @@ public class ShopScreen extends Page {
         t.row();
 
         t.row();
-        TextButton buyGold = new TextButton("Free Money", parent.skin);
-        buyGold.addListener(new ChangeListener() {
+        TextButton buyPowerup1 = new TextButton("Buy Powerup 1", parent.skin);
+        buyPowerup1.addListener(new ChangeListener() {
             @Override
             public void changed(ChangeEvent event, Actor actor) {
-                Pirate.plunder += 10;
+                parent.setScreen(parent.game);
             }
         });
-        t.add(buyGold).top().size(100, 25).spaceBottom(10);
+        t.add(buyPowerup1).top().size(100, 25).spaceBottom(10);
         t.row();
-        t.add(new Label("Get 10 free coins per click", parent.skin)).spaceBottom(10);
+        t.add(new Image(parent.skin, "coin")).top().left();
+        t.add(new Label("20", parent.skin)).right().spaceBottom(space);
+
+
+        t.row();
+        TextButton buyPowerup2 = new TextButton("Buy Powerup 2", parent.skin);
+        buyPowerup2.addListener(new ChangeListener() {
+            @Override
+            public void changed(ChangeEvent event, Actor actor) {
+                parent.setScreen(parent.game);
+            }
+        });
+        t.add(buyPowerup2).size(100, 25).top().spaceBottom(10);
         t.row();
         t.add(new Image(parent.skin, "coin")).top().left();
         t.add(new Label("10", parent.skin)).right().spaceBottom(space);
 
 
         t.row();
-        TextButton buyAmmo = new TextButton("Buy Ammo", parent.skin);
-        buyAmmo.addListener(new ChangeListener() {
+        TextButton buyPowerup3 = new TextButton("Buy Powerup 3", parent.skin);
+        buyPowerup3.addListener(new ChangeListener() {
             @Override
             public void changed(ChangeEvent event, Actor actor) {
-                if(Pirate.plunder >= 10){
-                    Pirate.ammo += 10; // add 10 ammo
-                    Pirate.plunder -= 10; // take away 10 coins
-                }
+                parent.setScreen(parent.game);
             }
         });
-        t.add(buyAmmo).size(100, 25).top().spaceBottom(10);
+        t.add(buyPowerup3).size(100, 25).top().spaceBottom(10);
         t.row();
-        t.add(new Label("Buy 10 cannons for 10 coins", parent.skin)).spaceBottom(10);
-        t.row();
-        t.add(new Image(parent.skin, "ball")).top().left();
+        t.add(new Image(parent.skin, "coin")).top().left().spaceBottom(space);
         t.add(new Label("10", parent.skin)).right().spaceBottom(space);
 
-
         t.row();
-        TextButton buyPowerups = new TextButton("Powerups", parent.skin);
-        buyPowerups.addListener(new ChangeListener() {
+        TextButton buyPowerup4 = new TextButton("Buy Powerup 4", parent.skin);
+        buyPowerup4.addListener(new ChangeListener() {
             @Override
             public void changed(ChangeEvent event, Actor actor) {
-                parent.setScreen(parent.powerup);
+                parent.setScreen(parent.game);
             }
         });
-        t.add(buyPowerups).size(100, 25).top().spaceBottom(10);
+        t.add(buyPowerup4).size(100, 25).top().spaceBottom(10);
         t.row();
-        t.add(new Label("Continue to the powerup page", parent.skin)).spaceBottom(space);
-
+        t.add(new Image(parent.skin, "coin")).top().left().spaceBottom(space);
+        t.add(new Label("10", parent.skin)).right().spaceBottom(space);
 
         t.row();
         TextButton back = new TextButton("Return", parent.skin);
         back.addListener(new ChangeListener() {
             @Override
             public void changed(ChangeEvent event, Actor actor) {
-                parent.setScreen(parent.game);
+                parent.setScreen(parent.shop);
             }
         });
         t.add(back).top().size(100, 25).spaceBottom(space);
@@ -135,8 +121,9 @@ public class ShopScreen extends Page {
         t.top();
 
         actors.add(t);
-    }
 
+
+    }
 
     @Override
     public void show() {


### PR DESCRIPTION
Added ability to press the buttons within the shop screen.

- [TEMP] Button to give player free money
- Button to buy ammo
- Button to continue to powerup screen

Added new Powerup Screen where player can purchase power ups (actual power ups not yet implemented).

Added ability to press ESC key to return through screen pages.

![image](https://user-images.githubusercontent.com/93789868/156187758-ba9f08b8-a19a-4255-8f4d-cfca833ea491.png)
![image](https://user-images.githubusercontent.com/93789868/156187795-c9450730-6f7e-421b-9de5-b31217b9f08a.png)
